### PR TITLE
chore(lint): use patched linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "nuxt-icon": "^0.6.6"
   },
   "devDependencies": {
-    "@maninak/eslint-config": "^0.1.2",
+    "@maninak/eslint-config": "^0.1.3",
     "@nuxt/devtools": "^1.0.4",
     "nuxt": "^3.8.2",
     "typescript": "^5.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ dependencies:
 
 devDependencies:
   '@maninak/eslint-config':
-    specifier: ^0.1.2
-    version: 0.1.2(tailwindcss@3.3.5)(vue-eslint-parser@9.3.2)
+    specifier: ^0.1.3
+    version: 0.1.3(tailwindcss@3.3.5)(vue-eslint-parser@9.3.2)
   '@nuxt/devtools':
     specifier: ^1.0.4
     version: 1.0.4(nuxt@3.8.2)(vite@4.5.0)
@@ -1030,8 +1030,8 @@ packages:
   /@kwsites/promise-deferred@1.1.1:
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
-  /@maninak/eslint-config@0.1.2(tailwindcss@3.3.5)(vue-eslint-parser@9.3.2):
-    resolution: {integrity: sha512-Rd/KQklT7EwyDDVwRO2j0ngtXcbL2dxB04Q1fIfL45mxv3xEvazaao6dpsRX27bSb24/3Z+OgM1F5mczGymUDQ==}
+  /@maninak/eslint-config@0.1.3(tailwindcss@3.3.5)(vue-eslint-parser@9.3.2):
+    resolution: {integrity: sha512-B63BOufczdZQB8c9O7O+8vnYPfHWJLFR+wWRyQeCJLGSkK9rkYIDafd5SZHbHnHE4pL6LKf6pIdUmXqKm0Mj6w==}
     engines: {npm: ^7}
     requiresBuild: true
     dependencies:
@@ -3856,7 +3856,7 @@ packages:
     resolution: {integrity: sha512-VsWmk/fftpjHBM7QFci0jZDLsc6Fh7jhenDHJ7Mbd/V0EMolcbezJRhtidE//3Liy5vEaVeX+U3skCQduWlmGA==}
     engines: {node: '>=16'}
     dependencies:
-      '@vue/compiler-sfc': 3.3.8
+      '@vue/compiler-sfc': 3.3.9
       picocolors: 1.0.0
       prettier: 3.1.0
       prettier-linter-helpers: 1.0.0


### PR DESCRIPTION
Resolves

TypeError: Key "rules": Key
"@typescript-eslint/explicit-function-return-type":
Could not find plugin "@typescript-eslint"

when trying to lint.

Seems to have been getting triggered, in among other cases,
when linting ts files under `/utils`.