### PR TITLE
chore(netlify): redirect reqs for all sub-paths through `/`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/"
+  status = 200


### PR DESCRIPTION
Fixes 404s when refreshing in non-root paths of the app