### PR TITLE
chore(nuxt): change dev server default port

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,6 +3,9 @@ import { radicleInterfaceOrigin } from './constants/config'
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   ssr: false,
+  devServer: {
+    port: 4000,
+  },
   modules: [
     'nuxt-security',
     '@pinia/nuxt',


### PR DESCRIPTION
Change the default port of the dev server to 4000 to avoid conflicts with radicle-interface (default port 3000) during development