### PR TITLE
feat(app): update design to better align with radicle-interface

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -126,3 +126,9 @@ body {
   background-color: var(--color-background-default);
   color: var(--color-foreground-contrast);
 }
+
+@layer components {
+  .button-solid {
+    @apply flex h-8 cursor-pointer items-center justify-center gap-2 rounded-sm bg-rad-fill-secondary px-3 text-sm font-semibold text-rad-foreground-match-background hover:bg-rad-fill-secondary-hover;
+  }
+}

--- a/components/Column.vue
+++ b/components/Column.vue
@@ -82,7 +82,7 @@ const doneTasksFilter = doneTaskStatuses
         <Icon :name="columnIcon.name" size="20" :class="`translate-y-1 ${columnIcon.class}`" />
         <h3 class="font-semibold">{{ title }}</h3>
 
-        <small class="text-rad-foreground-gray text-sm font-semibold">
+        <small class="text-sm font-semibold text-rad-foreground-dim">
           {{ tasksModel.length }}
         </small>
       </div>

--- a/components/ColumnCard.vue
+++ b/components/ColumnCard.vue
@@ -18,14 +18,16 @@ defineProps<Props>()
 
 <template>
   <article
-    class="flex flex-col gap-1 rounded bg-rad-background-float p-3 transition-opacity hover:bg-rad-fill-float-hover"
+    class="flex flex-col gap-1 rounded-sm border border-rad-border-hint bg-rad-background-float p-3 transition-opacity hover:bg-rad-fill-float-hover"
   >
     <small class="flex items-center gap-2">
       <span class="sr-only">{{ status.name }}</span>
       <UTooltip :text="status.name" :popper="{ placement: 'top' }">
         <Icon :name="status.icon.name" size="16" :class="status.icon.class" />
       </UTooltip>
-      <pre class="text-xs font-medium text-rad-foreground-dim">{{ id.slice(0, 7) }}</pre>
+      <pre class="text-xs font-medium text-rad-foreground-emphasized">{{
+        id.slice(0, 7)
+      }}</pre>
     </small>
 
     <h4>

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -46,21 +46,13 @@ async function handleImport() {
     <div class="flex gap-4">
       <template v-if="auth.isAuthenticated">
         <UTooltip text="Copy board state to clipboard">
-          <button
-            class="flex h-8 cursor-pointer items-center justify-center gap-2 rounded-sm bg-rad-fill-secondary px-3 text-sm font-semibold text-rad-foreground-match-background hover:bg-rad-fill-secondary-hover"
-            type="button"
-            @click="handleExport"
-          >
+          <button class="button-solid" type="button" @click="handleExport">
             <Icon :name="isExportSuccess ? 'octicon:check-16' : 'octicon:copy-16'" size="16" />
             Export
           </button>
         </UTooltip>
         <UTooltip text="Import board state from clipboard">
-          <button
-            class="flex h-8 cursor-pointer items-center justify-center gap-2 rounded-sm bg-rad-fill-secondary px-3 text-sm font-semibold text-rad-foreground-match-background hover:bg-rad-fill-secondary-hover"
-            type="button"
-            @click="handleImport"
-          >
+          <button class="button-solid" type="button" @click="handleImport">
             <Icon
               :name="isImportSuccess ? 'octicon:check-16' : 'octicon:arrow-down-16'"
               size="16"

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -46,22 +46,27 @@ async function handleImport() {
     <div class="flex gap-4">
       <template v-if="auth.isAuthenticated">
         <UTooltip text="Copy board state to clipboard">
-          <UButton
-            :icon="isExportSuccess ? 'i-heroicons-check' : 'i-heroicons-square-2-stack'"
-            class="rounded"
+          <button
+            class="flex h-8 cursor-pointer items-center justify-center gap-2 rounded-sm bg-rad-fill-secondary px-3 text-sm font-semibold text-rad-foreground-match-background hover:bg-rad-fill-secondary-hover"
+            type="button"
             @click="handleExport"
           >
+            <Icon :name="isExportSuccess ? 'octicon:check-16' : 'octicon:copy-16'" size="16" />
             Export
-          </UButton>
+          </button>
         </UTooltip>
         <UTooltip text="Import board state from clipboard">
-          <UButton
-            :icon="isImportSuccess ? 'i-heroicons-check' : 'i-heroicons-arrow-down-on-square'"
-            class="rounded"
+          <button
+            class="flex h-8 cursor-pointer items-center justify-center gap-2 rounded-sm bg-rad-fill-secondary px-3 text-sm font-semibold text-rad-foreground-match-background hover:bg-rad-fill-secondary-hover"
+            type="button"
             @click="handleImport"
           >
+            <Icon
+              :name="isImportSuccess ? 'octicon:check-16' : 'octicon:arrow-down-16'"
+              size="16"
+            />
             Import
-          </UButton>
+          </button>
         </UTooltip>
         <UTooltip v-if="isDebugging" text="Reset card order. All changes will be lost!">
           <UButton

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -14,6 +14,7 @@ export default defineNuxtConfig({
     '@vueuse/nuxt',
     '@nuxt/ui',
     'nuxt-icon',
+    '@nuxtjs/google-fonts',
     'nuxt-open-fetch',
   ],
   experimental: { typedPages: true },
@@ -42,6 +43,11 @@ export default defineNuxtConfig({
         ],
       },
       xFrameOptions: false,
+    },
+  },
+  googleFonts: {
+    families: {
+      Inter: '100..900',
     },
   },
   ui: { global: true, icons: 'all' },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -47,7 +47,8 @@ export default defineNuxtConfig({
   },
   googleFonts: {
     families: {
-      Inter: '100..900',
+      'Inter': '100..900',
+      'JetBrains Mono': '100..800',
     },
   },
   ui: { global: true, icons: 'all' },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@maninak/eslint-config": "^0.1.4",
     "@nuxt/devtools": "^1.0.8",
+    "@nuxtjs/google-fonts": "^3.2.0",
     "nuxt": "^3.11.1",
     "nuxt-open-fetch": "^0.6.2",
     "nuxt-security": "^1.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ devDependencies:
   '@nuxt/devtools':
     specifier: ^1.0.8
     version: 1.1.3(@unocss/reset@0.58.6)(floating-vue@5.2.2)(nuxt@3.11.1)(unocss@0.58.6)(vite@5.2.5)(vue@3.4.21)
+  '@nuxtjs/google-fonts':
+    specifier: ^3.2.0
+    version: 3.2.0
   nuxt:
     specifier: ^3.11.1
     version: 3.11.1(@unocss/reset@0.58.6)(eslint@8.57.0)(floating-vue@5.2.2)(typescript@5.4.3)(unocss@0.58.6)(vite@5.2.5)
@@ -1399,6 +1402,17 @@ packages:
       - rollup
       - supports-color
     dev: false
+
+  /@nuxtjs/google-fonts@3.2.0:
+    resolution: {integrity: sha512-cGAjDJoeQ2jm6VJCo4AtSmKO6KjsbO9RSLj8q261fD0lMVNMZCxkCxBkg8L0/2Vfgp+5QBHWVXL71p1tiybJFw==}
+    dependencies:
+      '@nuxt/kit': 3.11.1
+      google-fonts-helper: 3.5.0
+      pathe: 1.1.2
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+    dev: true
 
   /@nuxtjs/tailwindcss@6.11.4:
     resolution: {integrity: sha512-09cksgZD4seQj054Z/BeiwFg1bzQTol8KPulLDLGnmMTkEi21vj/z+WlXQRpVbN1GS9+oU9tcSsu2ufXCM3DBg==}
@@ -4828,6 +4842,15 @@ packages:
       path-type: 5.0.0
       slash: 5.1.0
       unicorn-magic: 0.1.0
+
+  /google-fonts-helper@3.5.0:
+    resolution: {integrity: sha512-QcKvB3Y+jJFpvBUp/iG1oe9BbKirrjwU2mzJzKGGb5czz6T93CCP9A8IlfCoZnko7b1+gPH3yVghXP5EBvunDg==}
+    dependencies:
+      deepmerge: 4.3.1
+      hookable: 5.5.3
+      ofetch: 1.3.4
+      ufo: 1.5.3
+    dev: true
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,7 @@ export default {
     extend: {
       fontFamily: {
         sans: ['Inter', ...defaultTheme.fontFamily.sans],
+        mono: ['JetBrains Mono', ...defaultTheme.fontFamily.mono],
       },
       colors: {
         'moody-blue': {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,8 +1,12 @@
 import type { Config } from 'tailwindcss'
+import defaultTheme from 'tailwindcss/defaultTheme'
 
 export default {
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['Inter', ...defaultTheme.fontFamily.sans],
+      },
       colors: {
         'moody-blue': {
           '50': '#ebedff',


### PR DESCRIPTION
Closes #62 

# Changes

- Added `Inter` (sans-serif) and `JetBrains Mono` (mono) fonts (the same fonts used by radicle-interface)
- Tweaked colors, borders, corner-radius of the columns and cards based on designs
- Tweaked import/export button styles to match radicle-interface

## Screenshot
![image](https://github.com/cytechmobile/radicle-planning-boards/assets/15063937/071f985d-c432-4af3-91e8-ee1aeaad20a0)
