### PR TITLE
feat(filtering): filter out done tasks older than 2 weeks

### DIFF
--- a/components/Column.vue
+++ b/components/Column.vue
@@ -8,7 +8,7 @@ const props = defineProps<{
   title: string
   tasks: Task[]
   isDefaultColumn?: boolean
-  isDoneColumn?: boolean
+  isRequired?: boolean
 }>()
 
 const tasksModel = ref<Task[]>([])
@@ -65,8 +65,7 @@ const columnIcon = computed(() => {
   return defaultIcon
 })
 
-const isRequired = computed(() => props.isDefaultColumn || props.isDoneColumn)
-const canBeDeleted = computed(() => !isRequired.value && props.tasks.length === 0)
+const canBeDeleted = computed(() => !props.isRequired && props.tasks.length === 0)
 const canCreateIssue = computed(() => props.isDefaultColumn || canEditLabels)
 const isDraggingDisabled = computed(
   () => !auth.isAuthenticated || !canEditLabels || tasks.isLoading,
@@ -94,14 +93,7 @@ const doneTasksFilter = doneTaskStatuses
       </div>
 
       <div class="flex items-center gap-2">
-        <UTooltip v-if="isDoneColumn" text="Showing items from the last two weeks">
-          <p class="sr-only">Showing items from the last two weeks</p>
-          <Icon
-            name="bx:info-circle"
-            size="20"
-            class="cursor-default text-rad-foreground-dim"
-          />
-        </UTooltip>
+        <slot name="actions"></slot>
         <template v-if="auth.isAuthenticated">
           <UTooltip
             v-if="!isRequired"
@@ -146,6 +138,7 @@ const doneTasksFilter = doneTaskStatuses
         <ColumnIssueCard v-if="isIssue(task)" :issue="task" />
         <ColumnPatchCard v-else-if="isPatch(task)" :patch="task" />
       </li>
+
       <NewColumnIssueCard
         v-if="isCreatingNewIssue"
         @submit="handleCreateIssue"

--- a/components/Column.vue
+++ b/components/Column.vue
@@ -93,21 +93,31 @@ const doneTasksFilter = doneTaskStatuses
         </small>
       </div>
 
-      <div v-if="auth.isAuthenticated" class="flex items-center gap-2">
-        <UTooltip
-          v-if="!isRequired"
-          :text="canBeDeleted ? 'Delete column' : 'The column must be empty to be deleted'"
-        >
-          <IconButton
-            label="Delete column"
-            icon="bx:trash"
-            :disabled="!canBeDeleted"
-            @click="board.removeColumn(title)"
+      <div class="flex items-center gap-2">
+        <UTooltip v-if="isDoneColumn" text="Showing items from the last two weeks">
+          <p class="sr-only">Showing items from the last two weeks</p>
+          <Icon
+            name="bx:info-circle"
+            size="20"
+            class="cursor-default text-rad-foreground-dim"
           />
         </UTooltip>
-        <UTooltip v-if="canCreateIssue" text="New issue">
-          <IconButton label="New issue" icon="bx:plus" @click="isCreatingNewIssue = true" />
-        </UTooltip>
+        <template v-if="auth.isAuthenticated">
+          <UTooltip
+            v-if="!isRequired"
+            :text="canBeDeleted ? 'Delete column' : 'The column must be empty to be deleted'"
+          >
+            <IconButton
+              label="Delete column"
+              icon="bx:trash"
+              :disabled="!canBeDeleted"
+              @click="board.removeColumn(title)"
+            />
+          </UTooltip>
+          <UTooltip v-if="canCreateIssue" text="New issue">
+            <IconButton label="New issue" icon="bx:plus" @click="isCreatingNewIssue = true" />
+          </UTooltip>
+        </template>
       </div>
     </div>
 

--- a/components/DoneColumn.vue
+++ b/components/DoneColumn.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import type { Task } from '~/types/tasks'
+
+defineProps<{
+  title: string
+  tasks: Task[]
+}>()
+
+const board = useBoardStore()
+
+function toggleRecentTasks() {
+  board.state.filter.recentDoneTasks = !board.state.filter.recentDoneTasks
+}
+
+const button = computed(() =>
+  board.state.filter.recentDoneTasks
+    ? {
+        label: 'Show all items',
+        icon: 'bx:calendar-plus',
+        class: 'text-rad-foreground-emphasized',
+      }
+    : {
+        label: 'Show recent items',
+        icon: 'bx:calendar-minus',
+        class: 'text-rad-foreground-dim',
+      },
+)
+</script>
+
+<template>
+  <Column :title="title" :tasks="tasks" is-required>
+    <template #actions>
+      <UTooltip :text="button.label">
+        <IconButton v-bind="button" @click="toggleRecentTasks" />
+      </UTooltip>
+    </template>
+  </Column>
+</template>

--- a/composables/use-tasks-fetch.ts
+++ b/composables/use-tasks-fetch.ts
@@ -135,13 +135,22 @@ export function useTasksFetch() {
       return null
     }
 
-    if (!board.state.filter.taskKind) {
-      return fetchedTasks.value
-    }
+    const twoWeeksAgo = new Date()
+    twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14)
 
-    const filteredTasks = fetchedTasks.value.filter(
-      (task) => board.state.filter.taskKind === task.rpb.kind,
-    )
+    const filteredTasks = fetchedTasks.value.filter((task) => {
+      // Filter by task kind
+      if (board.state.filter.taskKind && board.state.filter.taskKind !== task.rpb.kind) {
+        return false
+      }
+
+      // Filter done tasks by date
+      if (isTaskDone(task) && task.rpb.relevantDate < twoWeeksAgo) {
+        return false
+      }
+
+      return true
+    })
 
     return filteredTasks
   })

--- a/composables/use-tasks-fetch.ts
+++ b/composables/use-tasks-fetch.ts
@@ -145,7 +145,11 @@ export function useTasksFetch() {
       }
 
       // Filter done tasks by date
-      if (isTaskDone(task) && task.rpb.relevantDate < twoWeeksAgo) {
+      if (
+        board.state.filter.recentDoneTasks &&
+        isTaskDone(task) &&
+        task.rpb.relevantDate < twoWeeksAgo
+      ) {
         return false
       }
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@nuxt/ui": "^2.14.2",
     "@pinia/nuxt": "^0.5.1",
     "@vueuse/nuxt": "^10.9.0",
+    "deepmerge": "^4.3.1",
     "nuxt-icon": "^0.6.9",
     "vue-draggable-plus": "^0.3.5",
     "zod": "^3.22.4"

--- a/pages/[node]/[rid].vue
+++ b/pages/[node]/[rid].vue
@@ -40,14 +40,19 @@ function handleMoveColumn({ oldIndex, newIndex }: VueDraggableEvent) {
       handle="[data-column-handle]"
       @update="handleMoveColumn"
     >
-      <Column
-        v-for="column in columnsModel"
-        :key="column"
-        :title="column"
-        :tasks="tasks.tasksByColumn?.[column] ?? []"
-        :is-default-column="column === 'non-planned'"
-        :is-done-column="column === 'done'"
-      />
+      <template v-for="column in columnsModel" :key="column">
+        <DoneColumn
+          v-if="column === 'done'"
+          :title="column"
+          :tasks="tasks.tasksByColumn?.[column] ?? []"
+        />
+        <Column
+          v-else
+          :title="column"
+          :tasks="tasks.tasksByColumn?.[column] ?? []"
+          :is-default-column="column === 'non-planned'"
+        />
+      </template>
     </VueDraggable>
     <NewColumn v-if="auth.isAuthenticated" />
   </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   '@vueuse/nuxt':
     specifier: ^10.9.0
     version: 10.9.0(nuxt@3.11.1)(vue@3.4.21)
+  deepmerge:
+    specifier: ^4.3.1
+    version: 4.3.1
   nuxt-icon:
     specifier: ^0.6.9
     version: 0.6.10(nuxt@3.11.1)(vite@5.2.5)(vue@3.4.21)

--- a/stores/board.ts
+++ b/stores/board.ts
@@ -1,12 +1,13 @@
 import { useStorage } from '@vueuse/core'
 import z from 'zod'
+import deepMerge from 'deepmerge'
 import { initialColumns } from '~/constants/columns'
 
 const boardStateSchema = z.object({
   columns: z.array(z.string()),
   filter: z.object({
     taskKind: z.union([z.literal('issue'), z.literal('patch')]).optional(),
-    recentDoneTasks: z.boolean().optional(),
+    recentDoneTasks: z.boolean(),
   }),
 })
 
@@ -21,7 +22,12 @@ const initialBoardState: BoardState = {
 }
 
 export const useBoardStore = defineStore('board', () => {
-  const state = useStorage('RPB_board-state', initialBoardState)
+  const state = useStorage('RPB_board-state', initialBoardState, localStorage, {
+    mergeDefaults: (storageValue, defaults) =>
+      deepMerge(defaults, storageValue, {
+        arrayMerge: overwriteMerge,
+      }),
+  })
 
   function mergeColumns(parsedColumns: string[]) {
     const updatedColumns = [...new Set([...state.value.columns, ...parsedColumns])]

--- a/stores/board.ts
+++ b/stores/board.ts
@@ -6,6 +6,7 @@ const boardStateSchema = z.object({
   columns: z.array(z.string()),
   filter: z.object({
     taskKind: z.union([z.literal('issue'), z.literal('patch')]).optional(),
+    recentDoneTasks: z.boolean().optional(),
   }),
 })
 
@@ -15,6 +16,7 @@ const initialBoardState: BoardState = {
   columns: initialColumns,
   filter: {
     taskKind: 'issue',
+    recentDoneTasks: true,
   },
 }
 

--- a/types/tasks.ts
+++ b/types/tasks.ts
@@ -3,6 +3,10 @@ import type { RadicleIssue, RadiclePatch } from './httpd'
 export interface TaskProperties {
   column: string
   priority: number | null
+  /**
+   * The date used to filter tasks by. (creation date for issues, latest revision date for patches)
+   */
+  relevantDate: Date
 }
 
 export type Issue = RadicleIssue & {

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -8,3 +8,7 @@ export function initializeArrayForKey<Value>(
 
   return object[key] as Value[]
 }
+
+export function overwriteMerge<T>(_: T, source: T): T {
+  return source
+}

--- a/utils/tasks.ts
+++ b/utils/tasks.ts
@@ -18,7 +18,7 @@ export function isTaskDone(task: Task): boolean {
   return doneTaskStatuses.includes(task.state.status)
 }
 
-function getTaskProperties(radicleTask: RadicleTask): TaskProperties {
+function getTaskProperties(radicleTask: RadicleTask): Omit<TaskProperties, 'relevantDate'> {
   let column = 'non-planned'
   let priority: number | null = null
 
@@ -31,7 +31,7 @@ function getTaskProperties(radicleTask: RadicleTask): TaskProperties {
     }
   }
 
-  const rpbTaskProperties: TaskProperties = {
+  const rpbTaskProperties: Omit<TaskProperties, 'relevantDate'> = {
     column,
     priority,
   }
@@ -40,10 +40,15 @@ function getTaskProperties(radicleTask: RadicleTask): TaskProperties {
 }
 
 export function transformRadicleIssueToIssue(radicleIssue: RadicleIssue): Issue {
+  // Multiplying timestamp with 1000 to convert from seconds to milliseconds
+  const timestamp = (radicleIssue.discussion[0]?.timestamp ?? 0) * 1000
+  const relevantDate = new Date(timestamp)
+
   const issue: Issue = {
     ...radicleIssue,
     rpb: {
       kind: 'issue',
+      relevantDate,
       ...getTaskProperties(radicleIssue),
     },
   }
@@ -52,10 +57,15 @@ export function transformRadicleIssueToIssue(radicleIssue: RadicleIssue): Issue 
 }
 
 export function transformRadiclePatchToPatch(radiclePatch: RadiclePatch): Patch {
+  // Multiplying timestamp with 1000 to convert from seconds to milliseconds
+  const timestamp = (radiclePatch.revisions.at(-1)?.timestamp ?? 0) * 1000
+  const relevantDate = new Date(timestamp)
+
   const patch: Patch = {
     ...radiclePatch,
     rpb: {
       kind: 'patch',
+      relevantDate,
       ...getTaskProperties(radiclePatch),
     },
   }


### PR DESCRIPTION
# Changes

The done column will now hide any items older than 2 weeks. The age of an item is determined by the creation date for Issues, and the latest revision date for Patches. (These dates are the same ones used by `radicle-interface`)

An icon with a tooltip has been added to the `done` column to clarify this.

![Arc_3tYbBDX6cO](https://github.com/cytechmobile/radicle-planning-boards/assets/15063937/e3460470-5cb2-4e83-93b7-5d2cf693e575)