### PR TITLE
feat(cards): display task labels

### DIFF
--- a/components/ColumnCard.vue
+++ b/components/ColumnCard.vue
@@ -18,7 +18,7 @@ defineProps<Props>()
 
 <template>
   <article
-    class="flex flex-col gap-1 rounded-sm border border-rad-border-hint bg-rad-background-float p-3 transition-opacity hover:bg-rad-fill-float-hover"
+    class="group flex flex-col gap-1 rounded-sm border border-rad-border-hint bg-rad-background-float p-3 transition-opacity hover:bg-rad-fill-float-hover"
   >
     <small class="flex items-center gap-2">
       <span class="sr-only">{{ status.name }}</span>
@@ -36,11 +36,11 @@ defineProps<Props>()
       </a>
     </h4>
 
-    <ul v-if="labels.length > 0">
+    <ul v-if="labels.length > 0" class="flex flex-wrap gap-2">
       <li
         v-for="label in labels"
         :key="label"
-        class="mt-2 text-xs font-bold text-rad-foreground-emphasized"
+        class="mt-2 rounded-full bg-rad-fill-ghost px-2 py-1 text-xs font-semibold text-rad-foreground-contrast group-hover:bg-rad-background-float"
       >
         {{ label }}
       </li>

--- a/components/ColumnIssueCard.vue
+++ b/components/ColumnIssueCard.vue
@@ -23,10 +23,10 @@ const status = computed<ColumnCardStatus>(() => ({
 const radicleInterfaceBaseUrl = useRadicleInterfaceBaseUrl()
 const isDebugging = useIsDebugging()
 
-const dataLabels = computed(() =>
+const labels = computed(() =>
   isDebugging.value
-    ? props.issue.labels.filter((label) => label.startsWith(dataLabelNamespace))
-    : [],
+    ? props.issue.labels
+    : props.issue.labels.filter((label) => !label.startsWith(dataLabelNamespace)),
 )
 
 const href = computed(() =>
@@ -42,7 +42,7 @@ const href = computed(() =>
   <ColumnCard
     :id="issue.id"
     :title="issue.title"
-    :labels="dataLabels"
+    :labels="labels"
     :href="href"
     :status="status"
   />

--- a/components/ColumnPatchCard.vue
+++ b/components/ColumnPatchCard.vue
@@ -28,10 +28,10 @@ const status = computed<ColumnCardStatus>(() => ({
 const radicleInterfaceBaseUrl = useRadicleInterfaceBaseUrl()
 const isDebugging = useIsDebugging()
 
-const dataLabels = computed(() =>
+const labels = computed(() =>
   isDebugging.value
-    ? props.patch.labels.filter((label) => label.startsWith(dataLabelNamespace))
-    : [],
+    ? props.patch.labels
+    : props.patch.labels.filter((label) => !label.startsWith(dataLabelNamespace)),
 )
 
 const href = computed(() =>
@@ -47,7 +47,7 @@ const href = computed(() =>
   <ColumnCard
     :id="patch.id"
     :title="patch.title"
-    :labels="dataLabels"
+    :labels="labels"
     :href="href"
     :status="status"
   />


### PR DESCRIPTION
# Changes

Labels are now displayed in task cards. By default, data labels (`RPB:...`) will not be shown unless in debugging mode.

![image](https://github.com/cytechmobile/radicle-planning-boards/assets/15063937/be51a3bf-a334-405e-b266-2c1efe32c13b)
