### PR TITLE
feat(filtering): filter by query

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -127,6 +127,12 @@ body {
   color: var(--color-foreground-contrast);
 }
 
+::selection, mark {
+  /* !important used to override selection color */
+  background: var(--color-fill-yellow-iconic) !important;
+  color: var(--color-foreground-black);
+}
+
 @layer components {
   .button-solid {
     @apply flex h-8 cursor-pointer items-center justify-center gap-2 rounded-sm bg-rad-fill-secondary px-3 text-sm font-semibold text-rad-foreground-match-background hover:bg-rad-fill-secondary-hover;

--- a/components/Column.vue
+++ b/components/Column.vue
@@ -73,6 +73,15 @@ const isDraggingDisabled = computed(
 const doneTasksFilter = doneTaskStatuses
   .map((status) => `[data-status='${status}']`)
   .join(', ')
+
+// TODO: zac move this elsewhere
+const query = computed(() => {
+  if (!board.state.filter.query) {
+    return undefined
+  }
+
+  return new RegExp(board.state.filter.query, 'gi')
+})
 </script>
 
 <template>
@@ -135,8 +144,8 @@ const doneTasksFilter = doneTaskStatuses
           'hover:cursor-grab': !isDraggingDisabled && !isTaskDone(task),
         }"
       >
-        <ColumnIssueCard v-if="isIssue(task)" :issue="task" />
-        <ColumnPatchCard v-else-if="isPatch(task)" :patch="task" />
+        <ColumnIssueCard v-if="isIssue(task)" :issue="task" :query="query" />
+        <ColumnPatchCard v-else-if="isPatch(task)" :patch="task" :query="query" />
       </li>
 
       <NewColumnIssueCard

--- a/components/Column.vue
+++ b/components/Column.vue
@@ -123,7 +123,6 @@ const doneTasksFilter = doneTaskStatuses
       :data-column="title"
       :disabled="isDraggingDisabled"
       :filter="doneTasksFilter"
-      aria-live="polite"
       @end="handleMoveTask($event)"
     >
       <li

--- a/components/Column.vue
+++ b/components/Column.vue
@@ -73,16 +73,6 @@ const isDraggingDisabled = computed(
 const doneTasksFilter = doneTaskStatuses
   .map((status) => `[data-status='${status}']`)
   .join(', ')
-
-// TODO: zac move this elsewhere
-const { queryParams } = useQueryParamsStore()
-const query = computed(() => {
-  if (!queryParams.query) {
-    return undefined
-  }
-
-  return toRegExp(queryParams.query, 'i')
-})
 </script>
 
 <template>
@@ -146,8 +136,16 @@ const query = computed(() => {
           'hover:cursor-grab': !isDraggingDisabled && !isTaskDone(task),
         }"
       >
-        <ColumnIssueCard v-if="isIssue(task)" :issue="task" :query="query" />
-        <ColumnPatchCard v-else-if="isPatch(task)" :patch="task" :query="query" />
+        <ColumnIssueCard
+          v-if="isIssue(task)"
+          :issue="task"
+          :highlights="tasks.taskHighlights.get(task.id)"
+        />
+        <ColumnPatchCard
+          v-else-if="isPatch(task)"
+          :patch="task"
+          :highlights="tasks.taskHighlights.get(task.id)"
+        />
       </li>
 
       <NewColumnIssueCard

--- a/components/Column.vue
+++ b/components/Column.vue
@@ -81,7 +81,7 @@ const query = computed(() => {
     return undefined
   }
 
-  return new RegExp(queryParams.query, 'gi')
+  return toRegExp(queryParams.query, 'i')
 })
 </script>
 

--- a/components/Column.vue
+++ b/components/Column.vue
@@ -132,6 +132,7 @@ const query = computed(() => {
       :data-column="title"
       :disabled="isDraggingDisabled"
       :filter="doneTasksFilter"
+      aria-live="polite"
       @end="handleMoveTask($event)"
     >
       <li

--- a/components/Column.vue
+++ b/components/Column.vue
@@ -75,12 +75,13 @@ const doneTasksFilter = doneTaskStatuses
   .join(', ')
 
 // TODO: zac move this elsewhere
+const { queryParams } = useQueryParamsStore()
 const query = computed(() => {
-  if (!board.state.filter.query) {
+  if (!queryParams.query) {
     return undefined
   }
 
-  return new RegExp(board.state.filter.query, 'gi')
+  return new RegExp(queryParams.query, 'gi')
 })
 </script>
 

--- a/components/ColumnCard.vue
+++ b/components/ColumnCard.vue
@@ -13,11 +13,26 @@ interface Props {
     }
   }
   href: string
+  query?: RegExp
 }
 
 defineProps<Props>()
+
+// TODO: zac check whether this is safe and if not, fix it
+function getHighlightedText(text: string, query: RegExp | undefined) {
+  if (!query) {
+    return text
+  }
+
+  const queryRegExp = new RegExp(query, 'gi')
+
+  return text.replace(queryRegExp, (match) => {
+    return `<mark class="bg-rad-foreground-emphasized">${match}</mark>`
+  })
+}
 </script>
 
+<!-- eslint-disable vue/no-v-html -->
 <template>
   <article
     class="group flex flex-col gap-1 rounded-sm border border-rad-border-hint bg-rad-background-float p-3 transition-opacity hover:bg-rad-fill-float-hover"
@@ -27,15 +42,20 @@ defineProps<Props>()
       <UTooltip :text="status.name" :popper="{ placement: 'top' }">
         <Icon :name="status.icon.name" size="16" :class="status.icon.class" />
       </UTooltip>
-      <pre class="text-xs font-medium text-rad-foreground-emphasized">{{
-        id.slice(0, taskTruncatedIdLength)
-      }}</pre>
+
+      <pre
+        class="text-xs font-medium text-rad-foreground-emphasized"
+        v-html="getHighlightedText(id.slice(0, taskTruncatedIdLength), query)"
+      ></pre>
     </small>
 
     <h4>
-      <a :href="href" target="_blank" class="w-fit text-sm hover:underline">
-        {{ title }}
-      </a>
+      <a
+        :href="href"
+        target="_blank"
+        class="w-fit text-sm hover:underline"
+        v-html="getHighlightedText(title, query)"
+      ></a>
     </h4>
 
     <ul v-if="labels.length > 0" class="flex flex-wrap gap-2">
@@ -43,9 +63,8 @@ defineProps<Props>()
         v-for="label in labels"
         :key="label"
         class="mt-2 rounded-full bg-rad-fill-ghost px-2 py-1 text-xs font-semibold text-rad-foreground-contrast group-hover:bg-rad-background-float"
-      >
-        {{ label }}
-      </li>
+        v-html="getHighlightedText(label, query)"
+      ></li>
     </ul>
   </article>
 </template>

--- a/components/ColumnCard.vue
+++ b/components/ColumnCard.vue
@@ -19,13 +19,23 @@ interface Props {
 
 defineProps<Props>()
 
-// A function that takes an array of strings and a limit and returns the characters up to the limit in the same form as before
-// e.g. ['this', 'is', 'a', 'test'], 8 => ['this', 'is', 'a', 't']
-function truncateSegmentedText(text: string[], limit: number): string[] {
+/**
+ * Truncates segmented text based on a character limit.
+ *
+ * @param {string[]} segments - The segmented text to truncate.
+ * @param {number} limit - The character limit.
+ * @returns The truncated segmented text.
+ *
+ * @example
+ * ```ts
+ * truncateSegmentedText(['foo', 'bar'], 5) // ['foo', 'ba']
+ * ```
+ */
+function truncateSegmentedText(segments: string[], limit: number): string[] {
   const truncatedText = []
   let currentLength = 0
 
-  for (const segment of text) {
+  for (const segment of segments) {
     if (currentLength + segment.length > limit) {
       truncatedText.push(segment.slice(0, limit - currentLength))
       break

--- a/components/ColumnCard.vue
+++ b/components/ColumnCard.vue
@@ -27,7 +27,7 @@ function getHighlightedText(text: string, query: RegExp | undefined) {
   const queryRegExp = new RegExp(query, 'gi')
 
   return text.replace(queryRegExp, (match) => {
-    return `<mark class="bg-rad-foreground-emphasized">${match}</mark>`
+    return `<mark>${match}</mark>`
   })
 }
 </script>

--- a/components/ColumnCard.vue
+++ b/components/ColumnCard.vue
@@ -24,9 +24,7 @@ function getHighlightedText(text: string, query: RegExp | undefined) {
     return text
   }
 
-  const queryRegExp = new RegExp(query, 'gi')
-
-  return text.replace(queryRegExp, (match) => {
+  return text.replace(query, (match) => {
     return `<mark>${match}</mark>`
   })
 }

--- a/components/ColumnIssueCard.vue
+++ b/components/ColumnIssueCard.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import ColumnCard from './ColumnCard.vue'
-import type { Issue } from '~/types/tasks'
+import type { Issue, TaskHighlights } from '~/types/tasks'
 
 const props = defineProps<{
   issue: Issue
-  query?: RegExp
+  highlights?: TaskHighlights
 }>()
 
 type ColumnCardStatus = InstanceType<typeof ColumnCard>['$props']['status']
@@ -46,6 +46,6 @@ const href = computed(() =>
     :labels="labels"
     :href="href"
     :status="status"
-    :query="query"
+    :highlights="highlights"
   />
 </template>

--- a/components/ColumnIssueCard.vue
+++ b/components/ColumnIssueCard.vue
@@ -4,6 +4,7 @@ import type { Issue } from '~/types/tasks'
 
 const props = defineProps<{
   issue: Issue
+  query?: RegExp
 }>()
 
 type ColumnCardStatus = InstanceType<typeof ColumnCard>['$props']['status']
@@ -45,5 +46,6 @@ const href = computed(() =>
     :labels="labels"
     :href="href"
     :status="status"
+    :query="query"
   />
 </template>

--- a/components/ColumnIssueCard.vue
+++ b/components/ColumnIssueCard.vue
@@ -24,11 +24,31 @@ const status = computed<ColumnCardStatus>(() => ({
 const radicleInterfaceBaseUrl = useRadicleInterfaceBaseUrl()
 const isDebugging = useIsDebugging()
 
+// TODO: zac reduce duplication between ColumnIssueCard and ColumnPatchCard
 const labels = computed(() =>
   isDebugging.value
     ? props.issue.labels
     : props.issue.labels.filter((label) => !label.startsWith(dataLabelNamespace)),
 )
+
+const highlights = computed(() => {
+  if (!props.highlights) {
+    return undefined
+  }
+
+  if (isDebugging.value) {
+    return props.highlights
+  }
+
+  const filteredHighlightLabels = props.highlights.labels.filter(
+    (label) => !(label[0] ?? '').startsWith(dataLabelNamespace),
+  )
+
+  return {
+    ...props.highlights,
+    labels: filteredHighlightLabels,
+  }
+})
 
 const href = computed(() =>
   new URL(

--- a/components/ColumnPatchCard.vue
+++ b/components/ColumnPatchCard.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import ColumnCard from './ColumnCard.vue'
-import type { Patch } from '~/types/tasks'
+import type { Patch, TaskHighlights } from '~/types/tasks'
 
 const props = defineProps<{
   patch: Patch
-  query?: RegExp
+  highlights?: TaskHighlights
 }>()
 
 type ColumnCardStatus = InstanceType<typeof ColumnCard>['$props']['status']
@@ -51,6 +51,6 @@ const href = computed(() =>
     :labels="labels"
     :href="href"
     :status="status"
-    :query="query"
+    :highlights="highlights"
   />
 </template>

--- a/components/ColumnPatchCard.vue
+++ b/components/ColumnPatchCard.vue
@@ -29,11 +29,31 @@ const status = computed<ColumnCardStatus>(() => ({
 const radicleInterfaceBaseUrl = useRadicleInterfaceBaseUrl()
 const isDebugging = useIsDebugging()
 
+// TODO: zac reduce duplication between ColumnIssueCard and ColumnPatchCard
 const labels = computed(() =>
   isDebugging.value
     ? props.patch.labels
     : props.patch.labels.filter((label) => !label.startsWith(dataLabelNamespace)),
 )
+
+const highlights = computed(() => {
+  if (!props.highlights) {
+    return undefined
+  }
+
+  if (isDebugging.value) {
+    return props.highlights
+  }
+
+  const filteredHighlightLabels = props.highlights.labels.filter(
+    (label) => !(label[0] ?? '').startsWith(dataLabelNamespace),
+  )
+
+  return {
+    ...props.highlights,
+    labels: filteredHighlightLabels,
+  }
+})
 
 const href = computed(() =>
   new URL(

--- a/components/ColumnPatchCard.vue
+++ b/components/ColumnPatchCard.vue
@@ -4,6 +4,7 @@ import type { Patch } from '~/types/tasks'
 
 const props = defineProps<{
   patch: Patch
+  query?: RegExp
 }>()
 
 type ColumnCardStatus = InstanceType<typeof ColumnCard>['$props']['status']
@@ -50,5 +51,6 @@ const href = computed(() =>
     :labels="labels"
     :href="href"
     :status="status"
+    :query="query"
   />
 </template>

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -40,7 +40,7 @@ async function handleImport() {
 </script>
 
 <template>
-  <header class="flex justify-between gap-4 px-4">
+  <header class="flex justify-between gap-4 p-4">
     <div class="flex gap-4">
       <TaskKindSelect />
       <TaskFilterInput />

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -43,17 +43,7 @@ async function handleImport() {
   <header class="flex justify-between gap-4 px-4">
     <div class="flex gap-4">
       <TaskKindSelect />
-      <div
-        class="flex w-72 items-center gap-2 rounded-sm border border-rad-border-hint bg-rad-background-dip pl-2 focus-within:outline focus-within:outline-rad-fill-secondary hover:border-rad-border-default"
-      >
-        <Icon name="octicon:filter-16" class="text-rad-foreground-dim" />
-        <input
-          v-model="board.state.filter.query"
-          type="text"
-          class="h-full flex-1 bg-inherit outline-none"
-          placeholder="Filter"
-        />
-      </div>
+      <TaskFilterInput />
     </div>
 
     <div class="flex gap-4">

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -41,7 +41,20 @@ async function handleImport() {
 
 <template>
   <header class="flex justify-between gap-4 px-4">
-    <TaskKindSelect />
+    <div class="flex gap-4">
+      <TaskKindSelect />
+      <div
+        class="flex w-72 items-center gap-2 rounded-sm border border-rad-border-hint bg-rad-background-dip pl-2 focus-within:outline focus-within:outline-rad-fill-secondary hover:border-rad-border-default"
+      >
+        <Icon name="octicon:filter-16" class="text-rad-foreground-dim" />
+        <input
+          v-model="board.state.filter.query"
+          type="text"
+          class="h-full flex-1 bg-inherit outline-none"
+          placeholder="Filter"
+        />
+      </div>
+    </div>
 
     <div class="flex gap-4">
       <a

--- a/components/IconButton.vue
+++ b/components/IconButton.vue
@@ -8,7 +8,7 @@ defineProps<{
 <template>
   <button
     type="button"
-    class="w-fit rounded p-1 leading-none text-rad-foreground-dim hover:bg-rad-fill-ghost disabled:bg-transparent disabled:text-rad-foreground-disabled"
+    class="w-fit cursor-pointer rounded p-1 leading-none text-rad-foreground-dim hover:bg-rad-fill-ghost disabled:cursor-none disabled:bg-transparent disabled:text-rad-foreground-disabled"
   >
     <span class="sr-only">{{ label }}</span>
     <Icon :name="icon" size="20" />

--- a/components/IconButton.vue
+++ b/components/IconButton.vue
@@ -2,13 +2,15 @@
 defineProps<{
   label: string
   icon: string
+  padded?: boolean
 }>()
 </script>
 
 <template>
   <button
     type="button"
-    class="w-fit cursor-pointer rounded p-1 leading-none text-rad-foreground-dim hover:bg-rad-fill-ghost disabled:cursor-none disabled:bg-transparent disabled:text-rad-foreground-disabled"
+    class="w-fit cursor-pointer rounded leading-none text-rad-foreground-dim hover:bg-rad-fill-ghost disabled:cursor-none disabled:bg-transparent disabled:text-rad-foreground-disabled"
+    :class="{ 'p-1': padded ?? true }"
   >
     <span class="sr-only">{{ label }}</span>
     <Icon :name="icon" size="20" />

--- a/components/TaskFilterInput.vue
+++ b/components/TaskFilterInput.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 defineOptions({ inheritAttrs: false })
-const board = useBoardStore()
+
+const { queryParams } = useQueryParamsStore()
 
 const inputRef = ref<HTMLInputElement>()
 const { focused } = useFocus(inputRef)
@@ -10,6 +11,7 @@ onKeyStroke('/', (event) => {
   inputRef.value?.focus()
 })
 
+const board = useBoardStore()
 const label = computed(() => {
   switch (board.state.filter.taskKind) {
     case 'issue':
@@ -33,18 +35,14 @@ const label = computed(() => {
     <input
       v-bind="$attrs"
       ref="inputRef"
-      v-model="board.state.filter.query"
+      v-model="queryParams.query"
       type="text"
       class="h-full flex-1 bg-inherit outline-none"
       :aria-label="label"
       :placeholder="label"
     />
-    <UTooltip v-show="Boolean(board.state.filter.query)" text="Clear filters">
-      <IconButton
-        label="Clear filters"
-        icon="octicon:x-16"
-        @click="board.state.filter.query = ''"
-      />
+    <UTooltip v-show="Boolean(queryParams.query)" text="Clear filters">
+      <IconButton label="Clear filters" icon="octicon:x-16" @click="queryParams.query = ''" />
     </UTooltip>
     <kbd
       v-show="!focused"

--- a/components/TaskFilterInput.vue
+++ b/components/TaskFilterInput.vue
@@ -51,7 +51,7 @@ function handleMouseDown(event: MouseEvent) {
       type="text"
       class="h-full flex-1 bg-inherit outline-none"
       :aria-label="label"
-      :placeholder="label"
+      :placeholder="`${label}…`"
     />
     <UTooltip v-show="Boolean(queryParams.query)" text="Clear filters">
       <IconButton label="Clear filters" icon="octicon:x-16" @click="queryParams.query = ''" />

--- a/components/TaskFilterInput.vue
+++ b/components/TaskFilterInput.vue
@@ -68,18 +68,18 @@ const filterShortcut = `${isMac() ? 'Cmd' : 'Ctrl'}+F`
     <input
       v-bind="$attrs"
       ref="inputRef"
-      v-model="queryParams.query"
+      v-model="queryParams.filter"
       type="text"
       class="h-full flex-1 bg-inherit outline-none"
       :aria-label="label"
       :placeholder="`${label}…`"
     />
-    <UTooltip v-show="Boolean(queryParams.query)" text="Clear">
+    <UTooltip v-show="Boolean(queryParams.filter)" text="Clear">
       <IconButton
         label="Clear"
         icon="octicon:x-16"
         :padded="false"
-        @click="queryParams.query = ''"
+        @click="queryParams.filter = ''"
       />
     </UTooltip>
     <!-- TODO: zac hide on mobile devices -->

--- a/components/TaskFilterInput.vue
+++ b/components/TaskFilterInput.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+defineOptions({ inheritAttrs: false })
+const board = useBoardStore()
+
+const inputRef = ref<HTMLInputElement>()
+const { focused } = useFocus(inputRef)
+// TODO: zac disable this while a modal is open
+onKeyStroke('/', (event) => {
+  event.preventDefault()
+  inputRef.value?.focus()
+})
+
+const label = computed(() => {
+  switch (board.state.filter.taskKind) {
+    case 'issue':
+      return 'Filter issues'
+    case 'patch':
+      return 'Filter patches'
+    default:
+      return 'Filter tasks'
+  }
+})
+</script>
+
+<template>
+  <form
+    role="search"
+    class="flex w-96 cursor-text items-center gap-2 rounded-sm border border-rad-border-hint bg-rad-background-dip px-2 focus-within:outline focus-within:outline-rad-fill-secondary hover:border-rad-border-default"
+    @mousedown.prevent
+    @click="inputRef?.focus()"
+  >
+    <Icon name="octicon:filter-16" class="text-rad-foreground-dim" />
+    <input
+      v-bind="$attrs"
+      ref="inputRef"
+      v-model="board.state.filter.query"
+      type="text"
+      class="h-full flex-1 bg-inherit outline-none"
+      :aria-label="label"
+      :placeholder="label"
+    />
+    <UTooltip v-show="Boolean(board.state.filter.query)" text="Clear filters">
+      <IconButton
+        label="Clear filters"
+        icon="octicon:x-16"
+        @click="board.state.filter.query = ''"
+      />
+    </UTooltip>
+    <kbd
+      v-show="!focused"
+      class="flex h-5 min-w-5 items-center justify-center rounded-sm border border-rad-border-default px-1 font-sans text-xs font-medium"
+    >
+      /
+    </kbd>
+  </form>
+</template>

--- a/components/TaskFilterInput.vue
+++ b/components/TaskFilterInput.vue
@@ -7,6 +7,11 @@ const inputRef = ref<HTMLInputElement>()
 const { focused } = useFocus(inputRef)
 // TODO: zac disable this while a modal is open
 onKeyStroke('/', (event) => {
+  // Allow typing in input elements
+  if (/input|textarea|select/i.test((event.target as HTMLElement | null)?.tagName ?? '')) {
+    return
+  }
+
   event.preventDefault()
   inputRef.value?.focus()
 })
@@ -22,14 +27,21 @@ const label = computed(() => {
       return 'Filter tasks'
   }
 })
+
+// Prevents blur when clicking outside the input element
+function handleMouseDown(event: MouseEvent) {
+  if (event.target !== inputRef.value) {
+    event.preventDefault()
+  }
+}
 </script>
 
 <template>
   <form
     role="search"
     class="flex w-96 cursor-text items-center gap-2 rounded-sm border border-rad-border-hint bg-rad-background-dip px-2 focus-within:outline focus-within:outline-rad-fill-secondary hover:border-rad-border-default"
-    @mousedown.prevent
     @click="inputRef?.focus()"
+    @mousedown="handleMouseDown"
   >
     <Icon name="octicon:filter-16" class="text-rad-foreground-dim" />
     <input

--- a/components/TextWithHighlights.vue
+++ b/components/TextWithHighlights.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+interface Props {
+  content: string | string[]
+}
+
+defineProps<Props>()
+</script>
+
+
+<template>
+  <template v-if="typeof content === 'string'">
+    {{ content }}
+  </template>
+  <template v-for="(segment, index) in content" v-else :key="index">
+    <template v-if="isEven(index)">{{ segment }}</template>
+    <mark v-else>{{ segment }}</mark>
+  </template>
+</template>

--- a/composables/use-tasks-fetch.ts
+++ b/composables/use-tasks-fetch.ts
@@ -4,7 +4,6 @@ import type { Issue, Patch, Task } from '~/types/tasks'
 export function useTasksFetch() {
   const { $httpd } = useNuxtApp()
   const route = useRoute('node-rid')
-  const board = useBoardStore()
 
   async function fetchIssue(id: string): Promise<Issue> {
     const radicleIssue = await $httpd('/projects/{rid}/issues/{issue}', {
@@ -120,7 +119,7 @@ export function useTasksFetch() {
   }
 
   const {
-    data: fetchedTasks,
+    data: tasks,
     pending: areTasksPending,
     refresh: refreshTasks,
   } = useAsyncData('tasks', async () => {
@@ -128,35 +127,6 @@ export function useTasksFetch() {
     const tasks = issuesAndPatches.flat()
 
     return tasks
-  })
-
-  const tasks = computed(() => {
-    if (!fetchedTasks.value) {
-      return null
-    }
-
-    const twoWeeksAgo = new Date()
-    twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14)
-
-    const filteredTasks = fetchedTasks.value.filter((task) => {
-      // Filter by task kind
-      if (board.state.filter.taskKind && board.state.filter.taskKind !== task.rpb.kind) {
-        return false
-      }
-
-      // Filter done tasks by date
-      if (
-        board.state.filter.recentDoneTasks &&
-        isTaskDone(task) &&
-        task.rpb.relevantDate < twoWeeksAgo
-      ) {
-        return false
-      }
-
-      return true
-    })
-
-    return filteredTasks
   })
 
   return {

--- a/constants/elements.ts
+++ b/constants/elements.ts
@@ -1,0 +1,3 @@
+export const elementIds = {
+  taskFilterForm: 'task-filter-form',
+} as const

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -4,11 +4,7 @@ const tasksStore = useTasksStore()
 </script>
 
 <template>
-  <div
-    class="flex h-dvh flex-col gap-4 pt-4"
-    aria-live="polite"
-    :aria-busy="!tasksStore.isReady"
-  >
+  <div class="flex h-dvh flex-col" aria-live="polite" :aria-busy="!tasksStore.isReady">
     <Loading v-if="!tasksStore.isReady" />
     <template v-else>
       <Header />

--- a/pages/[node]/[rid].vue
+++ b/pages/[node]/[rid].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { VueDraggable } from 'vue-draggable-plus'
+import { elementIds } from '~/constants/elements'
 import type { VueDraggableEvent } from '~/types/vue-draggable-plus'
 
 const auth = useAuthStore()
@@ -28,8 +29,9 @@ function handleMoveColumn({ oldIndex, newIndex }: VueDraggableEvent) {
 </script>
 
 <template>
-  <div
+  <output
     v-if="columnsModel"
+    :form="elementIds.taskFilterForm"
     class="flex flex-1 gap-4 overflow-x-auto overflow-y-hidden px-4 pb-4"
   >
     <VueDraggable
@@ -55,5 +57,5 @@ function handleMoveColumn({ oldIndex, newIndex }: VueDraggableEvent) {
       </template>
     </VueDraggable>
     <NewColumn v-if="auth.isAuthenticated" />
-  </div>
+  </output>
 </template>

--- a/stores/board.ts
+++ b/stores/board.ts
@@ -6,6 +6,7 @@ import { initialColumns } from '~/constants/columns'
 const boardStateSchema = z.object({
   columns: z.array(z.string()),
   filter: z.object({
+    query: z.string().optional(),
     taskKind: z.union([z.literal('issue'), z.literal('patch')]).optional(),
     recentDoneTasks: z.boolean(),
   }),
@@ -16,6 +17,7 @@ type BoardState = z.infer<typeof boardStateSchema>
 const initialBoardState: BoardState = {
   columns: initialColumns,
   filter: {
+    query: '',
     taskKind: 'issue',
     recentDoneTasks: true,
   },
@@ -23,10 +25,9 @@ const initialBoardState: BoardState = {
 
 export const useBoardStore = defineStore('board', () => {
   const state = useStorage('RPB_board-state', initialBoardState, localStorage, {
-    mergeDefaults: (storageValue, defaults) =>
-      deepMerge(defaults, storageValue, {
-        arrayMerge: overwriteMerge,
-      }),
+    mergeDefaults: (storageValue, defaults) => {
+      return deepMerge(defaults, storageValue, { arrayMerge: overwriteMerge })
+    },
   })
 
   function mergeColumns(parsedColumns: string[]) {

--- a/stores/board.ts
+++ b/stores/board.ts
@@ -6,7 +6,6 @@ import { initialColumns } from '~/constants/columns'
 const boardStateSchema = z.object({
   columns: z.array(z.string()),
   filter: z.object({
-    query: z.string().optional(),
     taskKind: z.union([z.literal('issue'), z.literal('patch')]).optional(),
     recentDoneTasks: z.boolean(),
   }),
@@ -17,7 +16,6 @@ type BoardState = z.infer<typeof boardStateSchema>
 const initialBoardState: BoardState = {
   columns: initialColumns,
   filter: {
-    query: '',
     taskKind: 'issue',
     recentDoneTasks: true,
   },

--- a/stores/query-params.ts
+++ b/stores/query-params.ts
@@ -1,7 +1,7 @@
 import { debounceFilter } from '@vueuse/core'
 
 interface QueryParams extends Record<string, string | undefined> {
-  query?: string
+  filter?: string
 }
 
 export const useQueryParamsStore = defineStore('query-params', () => {

--- a/stores/query-params.ts
+++ b/stores/query-params.ts
@@ -1,0 +1,60 @@
+import { debounceFilter } from '@vueuse/core'
+
+interface QueryParams extends Record<string, string | undefined> {
+  query?: string
+}
+
+export const useQueryParamsStore = defineStore('query-params', () => {
+  const isInIframe = inIframe()
+
+  if (!isInIframe) {
+    const queryParams = useUrlSearchParams<QueryParams>('history')
+
+    return { queryParams }
+  }
+
+  const hostAppQueryParams = reactive<QueryParams>({})
+  const postMessage = usePostMessageToRadicleInterface()
+
+  onMounted(() => {
+    postMessage({ type: 'request-query-params' })
+  })
+
+  const { pause, resume } = watchPausable(
+    hostAppQueryParams,
+    () => {
+      postMessage({
+        type: 'set-query-params',
+        // ! Sending the reactive object directly causes an object cloning error
+        queryParams: Object.assign({}, hostAppQueryParams),
+      })
+    },
+    // ! Debouncing is required to:
+    // - Prevent an infinite loop when too many changes happen in a short time
+    // - Avoid spamming the host app with too many messages
+    { eventFilter: debounceFilter(500) },
+  )
+
+  useRadicleInterfaceMessage('query-params-updated', (message) => {
+    pause()
+
+    const unusedKeys = Object.keys(hostAppQueryParams)
+
+    for (const [key, value] of Object.entries(message.queryParams)) {
+      hostAppQueryParams[key] = value
+
+      const keyIndex = unusedKeys.indexOf(key)
+      if (keyIndex !== -1) {
+        unusedKeys.splice(keyIndex, 1)
+      }
+    }
+
+    unusedKeys.forEach((key) => delete hostAppQueryParams[key])
+
+    resume()
+  })
+
+  return {
+    queryParams: hostAppQueryParams,
+  }
+})

--- a/stores/tasks.ts
+++ b/stores/tasks.ts
@@ -230,12 +230,13 @@ function useFilteredTasks() {
     return broadlyFilteredTasks
   })
 
+  const { queryParams } = useQueryParamsStore()
   const filteredTasks = computed<Task[] | undefined>(() => {
     if (!broadlyFilteredTasks.value) {
       return undefined
     }
 
-    const query = board.state.filter.query?.trim()
+    const query = queryParams.query?.trim()
     if (!query) {
       return broadlyFilteredTasks.value
     }

--- a/stores/tasks.ts
+++ b/stores/tasks.ts
@@ -259,7 +259,9 @@ function useFilteredTasks() {
       (task) =>
         regExp.test(task.title) ||
         regExp.test(task.id) ||
-        task.labels.some((label) => regExp.test(label)),
+        task.labels.some(
+          (label) => !label.startsWith(dataLabelNamespace) && regExp.test(label),
+        ),
     )
 
     return filteredTasks
@@ -277,7 +279,14 @@ function useFilteredTasks() {
       const taskHighlights = {
         id: task.id.split(regExp),
         title: task.title.split(regExp),
-        labels: task.labels.map((label) => label.split(regExp)),
+        labels: task.labels.map((label) => {
+          if (label.startsWith(dataLabelNamespace)) {
+            return [label]
+          }
+          const segments = label.split(regExp)
+
+          return segments
+        }),
       }
 
       highlights.set(task.id, taskHighlights)

--- a/stores/tasks.ts
+++ b/stores/tasks.ts
@@ -233,7 +233,7 @@ function useFilteredTasks() {
 
   const { queryParams } = useQueryParamsStore()
   const queryRegExp = computed(() => {
-    const query = queryParams.query?.trim()
+    const query = queryParams.filter?.trim()
     if (!query) {
       return undefined
     }

--- a/stores/tasks.ts
+++ b/stores/tasks.ts
@@ -241,7 +241,7 @@ function useFilteredTasks() {
       return broadlyFilteredTasks.value
     }
 
-    const queryRegExp = new RegExp(query, 'gi')
+    const queryRegExp = toRegExp(query, 'i')
     const filteredTasks = broadlyFilteredTasks.value.filter(
       (task) =>
         queryRegExp.test(task.title) ||

--- a/test/components/ColumnCard.nuxt.test.ts
+++ b/test/components/ColumnCard.nuxt.test.ts
@@ -3,6 +3,7 @@ import { renderSuspended } from '@nuxt/test-utils/runtime'
 import { ColumnCard } from '#components'
 import { taskTruncatedIdLength } from '~/constants/tasks'
 
+// TODO: zac write tests for highlighting
 describe('<ColumnCard />', () => {
   it('renders the title (link as new tab), status, id (truncated), and labels', async () => {
     const props = {

--- a/types/messages.ts
+++ b/types/messages.ts
@@ -12,10 +12,15 @@ export const incomingMessageSchema = z.union([
   z.object({
     type: z.literal('remove-auth-token'),
   }),
+  z.object({
+    type: z.literal('query-params-updated'),
+    queryParams: z.record(z.string(), z.string()),
+  }),
 ])
 
 export type IncomingMessage = z.infer<typeof incomingMessageSchema>
 
-export interface OutgoingMessage {
-  type: 'request-auth-token'
-}
+export type OutgoingMessage =
+  | { type: 'request-auth-token' }
+  | { type: 'request-query-params' }
+  | { type: 'set-query-params'; queryParams: Record<string, string | undefined> }

--- a/types/tasks.ts
+++ b/types/tasks.ts
@@ -24,3 +24,27 @@ export type Patch = RadiclePatch & {
 export type RadicleTask = RadicleIssue | RadiclePatch
 
 export type Task = Issue | Patch
+
+/**
+ * Represents the text properties of a task to be highlighted.
+ *
+ * Each string array represents a string, split in segments so that odd indexes are
+ * highlighted while even indexes are not.
+ *
+ * @example
+ * ```ts
+ * // The **quick** brown fox jumps over the lazy **dog**.
+ * ['The ', 'quick', ' brown fox jumps over the lazy ', 'dog', '.']
+ * ```
+ *
+ * @example
+ * ```ts
+ * // **The** quick brown fox jumps over the lazy **dog.**
+ * ['', 'The', ' quick brown fox jumps over the lazy ', 'dog.']
+ * ```
+ */
+export interface TaskHighlights {
+  id: string[]
+  title: string[]
+  labels: string[][]
+}

--- a/utils/iframe.ts
+++ b/utils/iframe.ts
@@ -1,0 +1,11 @@
+/**
+ * Checks if the current page is loaded inside an iframe.
+ * @returns A boolean value indicating whether the page is loaded inside an iframe.
+ */
+export function inIframe(): boolean {
+  try {
+    return globalThis.self !== globalThis.top
+  } catch {
+    return true
+  }
+}

--- a/utils/number.ts
+++ b/utils/number.ts
@@ -1,0 +1,9 @@
+/**
+ * Checks if a number is even.
+ *
+ * @param {number} number - The number to check.
+ * @returns A boolean indicating if the number is even.
+ */
+export function isEven(number: number): boolean {
+  return number % 2 === 0
+}

--- a/utils/string.ts
+++ b/utils/string.ts
@@ -1,0 +1,23 @@
+/**
+ * Escapes any special characters from a string and converts it to a regular expression.
+ *
+ * @param {string} string - The string to convert to a regular expression.
+ * @param {string} [flags] - Optional flags to be applied to the regular expression.
+ * @returns A regular expression object.
+ *
+ * @example
+ * ```ts
+ * toRegExp('foo.bar') // /foo\.bar/
+ * ```
+ *
+ * @example
+ * ```ts
+ * toRegExp('foo.bar', 'i') // /foo\.bar/i
+ * ```
+ */
+export function toRegExp(string: string, flags?: string): RegExp {
+  const escapedString = string.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&')
+  const regExp = new RegExp(escapedString, flags)
+
+  return regExp
+}

--- a/utils/string.ts
+++ b/utils/string.ts
@@ -1,23 +1,16 @@
 /**
- * Escapes any special characters from a string and converts it to a regular expression.
+ * Escapes special characters in a string so that it can be used in a regular expression.
  *
- * @param {string} string - The string to convert to a regular expression.
- * @param {string} [flags] - Optional flags to be applied to the regular expression.
- * @returns A regular expression object.
- *
- * @example
- * ```ts
- * toRegExp('foo.bar') // /foo\.bar/
- * ```
+ * @param {string} string - The string to escape.
+ * @returns The escaped string.
  *
  * @example
  * ```ts
- * toRegExp('foo.bar', 'i') // /foo\.bar/i
+ * escapeString('foo.bar') // 'foo\.bar'
  * ```
  */
-export function toRegExp(string: string, flags?: string): RegExp {
-  const escapedString = string.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&')
-  const regExp = new RegExp(escapedString, flags)
+export function escapeRegExp(string: string): string {
+  const escapedString = string.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')
 
-  return regExp
+  return escapedString
 }


### PR DESCRIPTION
Closes [5288652](https://app.radicle.xyz/nodes/seed.radicle.gr/rad:z2BdUVZFvHdxRfdtGJQdSH2kyXNM6/issues/5288652c8587b5579d33ce2461601ce5bfd8d178)

## Product-y Notes

> For @gsaslis and @maninak 

### Dimming the rest of the UI while the filter input is focused

Tried this, got the best results with opacity around 80% but even then it was a bit hit and miss between dark and light themes. Might be able to make it work with more tinkering but elected not to spend any more time on it for the time being.

### `Ctrl/Cmd+F` as the shortcut for the input

I didn't really like the idea of hijacking an existing browser shortcut. After some research I found `/`to be a pretty common shortcut for search so I went with that.

### Input width

Given that we want filtering qualifiers in the future (e.g. `creator:zac`), queries might get long. I'm thinking we might want to have the input span the remaining available header width. Thoughts?

### Hiding the keyboard shortcut advertisement during input focus

I'm on the fence about this. If you feel we should keep it visible while the input is focused, just let me know and I'll change it.

## Tech-y/Code-y Notes

> For @maninak 

### To dos

I've left a few Todos which I want to do (get it?), either before this gets merged or after in another PR depending on time. Either way I didn't want them to hold up the review.

### [Accessibility] Using the `output` element and `<input type="search" />`

#### `output` element

I couldn't really find any information or cases of it being used to indicate search results. So instead, I set `aria-live="polite"` in each columns' `ul` element.

#### `<input type="search" />`

This is implemented [differently across browsers](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search#differences_between_search_and_text_types) which would compromise our UX. In addition, I couldn't find information indicating that `type="search"` has any accessibility impact. 

Instead, I used `type="text"` with an aria-label and wrapped it in a `form` with `role="search"` [as suggested by MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search#search_form_labels_and_accessibility)